### PR TITLE
Add WordPress Doc Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "doc/wordpress/Dice_Simulation_Online_Doc"]
+	path = doc/wordpress/Dice_Simulation_Online_Doc
+	url = https://github.com/Teddy-van-Jerry/Dice_Simulation_Online_Doc.git

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ Here the task is split into four components:
 ### Version 1.x
 
 Offer visual simulation using OpenGL.
+
+## Documentation
+
+Documentation is published at https://dice.teddy-van-jerry and is in the repo [Teddy-van-Jerry/Dice_Simulation_Online_Doc](https://github.com/Teddy-van-Jerry/Dice_Simulation_Online_Doc) or [Dice-Simulation/Dice_Simulation_Online_Doc](https://github.com/Teddy-van-Jerry/Dice_Simulation_Online_Doc).

--- a/doc/wordpress/README.md
+++ b/doc/wordpress/README.md
@@ -1,0 +1,3 @@
+# `doc/wordpress`
+
+Articles on wordpress website: https://dice.teddy-van-jerry.org.


### PR DESCRIPTION
This is from repo: https://github.com/Teddy-van-Jerry/Dice_Simulation_Online_Doc